### PR TITLE
Ignore Cargo.lock file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /thesis.pdf
+
+Cargo.lock


### PR DESCRIPTION
Per [the usual recommendation](http://doc.crates.io/guide.html#cargotoml-vs-cargolock):

> If you’re building a library that other projects will depend on, put `Cargo.lock` in your `.gitignore`. If you’re building an executable like a command-line tool or an application, check `Cargo.lock` into `git`.
