### PR TITLE
allow input via stdin (Fixes #5)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,7 +707,7 @@ impl std::fmt::Display for MarkdownExtension {
 #[derive(Clone, Debug)]
 pub enum InputKind {
     Files(Vec<PathBuf>),
-    /// passed to the pandoc through stdin
+    /// passed to the pandoc executable through stdin
     Pipe(String),
 }
 


### PR DESCRIPTION
The set_input method now allows input to be piped in via stdin. That fixes #5.