### PR TITLE
Update README.md to set output using OutputKind

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     ```rust
     let mut pandoc = pandoc::new();
     pandoc.add_input("hello_world.md");
-    pandoc.set_output("hello_world.pdf");
+    pandoc.set_output(OutputKind::File("hello_world.pdf".to_string()));
     pandoc.execute().unwrap();
     ```
 


### PR DESCRIPTION
The API must have been revamped at some point to support both outputs to a file and to a string, but this example was not updated accordingly.