### PR TITLE
OutputKind: Switch from String to PathBuf for filenames

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -718,7 +718,7 @@ pub enum InputKind {
 /// Specify whether to generate a file or pipe the output to stdout.
 #[derive(Clone, Debug)]
 pub enum OutputKind {
-    File(String),
+    File(PathBuf),
     Pipe,
 }
 
@@ -1096,7 +1096,7 @@ impl Pandoc {
         let output = self.run()?;
 
         match output_kind {
-            Some(OutputKind::File(name)) => Ok(PandocOutput::ToFile(PathBuf::from(name))),
+            Some(OutputKind::File(name)) => Ok(PandocOutput::ToFile(name)),
             Some(OutputKind::Pipe) => match String::from_utf8(output) {
                 Ok(string) => Ok(PandocOutput::ToBuffer(string)),
                 Err(err) => Err(PandocError::from(err.utf8_error())),

--- a/tests/sanity.rs
+++ b/tests/sanity.rs
@@ -9,7 +9,7 @@ fn creation() {
     let mut pandoc = pandoc::new();
 
     pandoc.add_input("cake");
-    pandoc.set_output(OutputKind::File(String::from("lie")));
+    pandoc.set_output(OutputKind::File(PathBuf::from("lie")));
     pandoc.set_chapters();
     pandoc.set_number_sections();
     pandoc.set_latex_template("template.tex");


### PR DESCRIPTION
File names are more properly PathBuf as they are in all other
places in the code.  Change OutputKind::File() away from String
to keep things consistent.

This is a breaking change and will thus need the next release to be
at minimum version 0.8.0

Fixes: #23