### PR TITLE
Filters: Support closures for filtering

### DIFF
--- a/tests/sanity.rs
+++ b/tests/sanity.rs
@@ -21,4 +21,7 @@ fn creation() {
     pandoc.add_option(IndentedCodeClasses("cake".to_string()));
     let path = PathBuf::new();
     pandoc.add_option(Filter(path));
+    let pat = "from";
+    let rep = "to";
+    pandoc.add_filter(move |s| s.replace(pat, rep));
 }


### PR DESCRIPTION
In order to support somewhat more complex filtering cases, while
working on a project we encountered the need for closures rather
than simply filter functions.  This change is the simplest possible
which permits the use of `'static + Fn(String) -> String` closures
to increase flexibility.

The internal use of `Rc` means that we swap from `Send + Sync` on
the `Pandoc` struct to `!Send + !Sync` -- I can swap that to `Arc` if the
change is unacceptable, otherwise this is also a breaking change.
