### PR TITLE
Prep 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pandoc"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 authors = [
   "Oliver Schneider <rust-pandoc61914191@oli-obk.de>",

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
     ```toml
     [dependencies]
-    open = "*"
-    pandoc = { path = "D:\\rust_pandoc\\"}
+    pandoc = "0.8"
    ```
 
 3. create a pandoc builder and execute it


### PR DESCRIPTION
I believe this is all we need for releasing 0.8.  I don't intend to add myself to the authors list in Cargo.toml for now because I can't guarantee to be around to deal with issues reported unless they're in bits I added.

This is the git-side of #28 and if @oli-obk wants they can push a tag (I note only v0.5.0 has a tag currently).

Once merged, I am happy to do a cargo publish.