### PR TITLE
Add ShiftHeadingLevelBy.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,8 @@ pub enum PandocOption {
     Smart,
     /// --old-dashes
     OldDashes,
-    /// DEPRECATED (replaced by ShiftHeadingLevelBy): --base-header-level=NUMBER
+    /// --base-header-level=NUMBER
+    #[deprecated(note = "replaced by ShiftHeadingLevelBy")]
     BaseHeaderLevel(u32),
     /// --shift-heading-level-by=NUMBER,
     ShiftHeadingLevelBy(i32),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,10 @@ pub enum PandocOption {
     Smart,
     /// --old-dashes
     OldDashes,
-    /// --base-header-level=NUMBER
+    /// DEPRECATED (replaced by ShiftHeadingLevelBy): --base-header-level=NUMBER
     BaseHeaderLevel(u32),
+    /// --shift-heading-level-by=NUMBER,
+    ShiftHeadingLevelBy(i32),
     /// --indented-code-classes=STRING
     IndentedCodeClasses(String),
     /// -F PROGRAM --filter=PROGRAM
@@ -258,6 +260,7 @@ impl PandocOption {
             Smart => pandoc.args(&["--smart"]),
             OldDashes => pandoc.args(&["--old-dashes"]),
             BaseHeaderLevel(n) => pandoc.args(&[&format!("--base-header-level={}", n)]),
+            ShiftHeadingLevelBy(n) => pandoc.args(&[&format!("--shift-heading-level-by={}", n)]),
             IndentedCodeClasses(ref s) => pandoc.args(&[&format!("--indented-code-classes={}", s)]),
             Filter(ref program) => pandoc.args(&[&format!("--filter={}", program.display())]),
             Normalize => pandoc.args(&["--normalize"]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,7 @@ impl PandocOption {
             ParseRaw => pandoc.args(&["--parse-raw"]),
             Smart => pandoc.args(&["--smart"]),
             OldDashes => pandoc.args(&["--old-dashes"]),
+            #[allow(deprecated)]
             BaseHeaderLevel(n) => pandoc.args(&[&format!("--base-header-level={}", n)]),
             ShiftHeadingLevelBy(n) => pandoc.args(&[&format!("--shift-heading-level-by={}", n)]),
             IndentedCodeClasses(ref s) => pandoc.args(&[&format!("--indented-code-classes={}", s)]),


### PR DESCRIPTION
This is to replace the deprecated BaseHeaderLevel option which is still
present for backward compatibility.