### PR TITLE
Support piped PDF output. Closes #32.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,8 @@ pub enum OutputFormat {
     Beamer,
     /// ConTeXt
     Context,
+    /// PDF (via LaTeX)
+    Pdf,
     /// Groff man
     Man,
     /// MediaWiki markup
@@ -496,6 +498,7 @@ impl std::fmt::Display for OutputFormat {
             Latex => write!(fmt, "latex"),
             Beamer => write!(fmt, "beamer"),
             Context => write!(fmt, "context"),
+            Pdf => write!(fmt, "pdf"),
             Man => write!(fmt, "man"),
             MediaWiki => write!(fmt, "mediawiki"),
             Dokuwiki => write!(fmt, "dokuwiki"),
@@ -1003,7 +1006,10 @@ impl Pandoc {
                 cmd.arg("-o").arg(filename);
             }
             OutputKind::Pipe => {
-                cmd.stdout(std::process::Stdio::piped());
+                match self.output_format.as_ref().map(|t| &t.0 ) {
+                    Some(OutputFormat::Pdf) => cmd.arg("-o").arg("-").stdout(std::process::Stdio::piped()),
+                    _ => cmd.stdout(std::process::Stdio::piped()),
+                };
             }
         }
 


### PR DESCRIPTION
This adds support for PDF output, but a breaking change is necessary since we
are now exposing the raw bytes returned by pandoc instead of first trying to
decode them as UTF-8. This step is unnecessary since it will usually be a no-op
and will fail in case of binary formats.

Alternatively, we could introduce a new `PandocOutput` variant (e.g.
`PandocOutput::ToBufferBinary`) for binary output which turns out not to be
valid UTF-8. Then we wouldn't raise a UTF-8 decoding error but would simply
return the raw bytes in this variant instead. This would retain the neatness of
the current API which gives you a `String` when it's possible and raw bytes
when not.