### PR TITLE
Adds ResourcePath PandocOption.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,8 @@ pub enum PandocOption {
     IgnoreArgs,
     /// --verbose
     Verbose,
+    /// --resource-path=PATH
+    ResourcePath(Vec<PathBuf>),
 }
 
 impl PandocOption {
@@ -370,6 +372,15 @@ impl PandocOption {
             DumpArgs => pandoc.args(&["--dump-args"]),
             IgnoreArgs => pandoc.args(&["--ignore-args"]),
             Verbose => pandoc.args(&["--verbose"]),
+            ResourcePath(ref paths) => {
+                let delimiter = if cfg!(windows) {
+                    ";"
+                } else {
+                    ":"
+                };
+                let paths = paths.iter().map(|path| path.display().to_string()).join(delimiter);
+                pandoc.args(&[&format!("--resource-path={}", paths)])
+            }
         }
     }
 }


### PR DESCRIPTION
When generating outputs that embed resources such as images (this
includes PDF, ePub, amongst other formats), typically pandoc looks in
the working directory to find these files. Using the `--resource-path`
option, which was introduced in recent versions of Pandoc (2.10), this
behhaviour can be changed.

With this commit, multiple resource paths can be specified. As the
pandoc manual states, these are chained with a colon (':') on most
operating systems, but with a semicolon (';') on the 'Windows' operating
system.