### PR TITLE
Added heap size limit option via runtime settings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,14 @@ pub enum PandocOption {
     Verbose,
     /// --resource-path=PATH
     ResourcePath(Vec<PathBuf>),
+    /// +RTS OPTIONS -RTS
+    RuntimeSystem(Vec<PandocRuntimeSystemOption>),
+}
+
+#[derive(Clone, Debug)]
+pub enum PandocRuntimeSystemOption {
+    /// -M<size>
+    MaximumHeapMemory(String),
 }
 
 impl PandocOption {
@@ -379,6 +387,17 @@ impl PandocOption {
                     .map(|path| path.display().to_string())
                     .join(delimiter);
                 pandoc.args(&[&format!("--resource-path={}", paths)])
+            }
+            RuntimeSystem(ref rts_options) => {
+                pandoc.args(&["+RTS"]);
+                for option in rts_options {
+                    match option {
+                        PandocRuntimeSystemOption::MaximumHeapMemory(ref s) => {
+                            pandoc.args(&[&format!("-M{}", s)]);
+                        }
+                    }
+                }
+                pandoc.args(&["-RTS"])
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,21 @@ pub enum PandocOption {
     /// --resource-path=PATH
     ResourcePath(Vec<PathBuf>),
     /// +RTS OPTIONS -RTS
+    ///
+    /// In Pandoc's "A note on security" section of the manual ([link](https://pandoc.org/MANUAL.html#a-note-on-security)), there is a recommendation to set a heap size limit to prevent pathological corner cases.
+    ///
+    /// The full list of "RTS" options can be found in the Haskell "Runtime control" section of the manual ([link](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/runtime_control.html)).
+    /// The Runtime System options are way more extensive than the -M option, and cover a lot of use-cases that aren't needed while using pandoc in a production setting.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```
+    /// let mut pandoc = pandoc::new();
+    /// pandoc.add_option(pandoc::PandocOption::RuntimeSystem(vec![
+    ///   // Limit the heap size to 512 MB while processing an arbitrary input file.
+    ///   pandoc::PandocRuntimeSystemOption::MaximumHeapMemory("512M".to_string()),
+    /// ]));
+    /// ```
     RuntimeSystem(Vec<PandocRuntimeSystemOption>),
 }
 


### PR DESCRIPTION
Hello, and thanks a lot for this crate !

In Pandoc's "A note on security" section of the manual ([link](https://pandoc.org/MANUAL.html#a-note-on-security)), there is a recommendation to set a heap size limit to prevent pathological corner cases. The option was however not available as of now via this crate.

The full list of "RTS" options can be found in the Haskell "Runtime control" section of the manual ([link](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/runtime_control.html)). The Runtime System options are way more extensive than the `-M` option, and cover a lot of use-cases that aren't needed while using `pandoc` in a production setting.

To support both the `+RTS -M<size> -RTS` setting recommended by Pandoc, and to allow adding options to the runtime system in the future, this Pull Request adds :
- The `PandocOption::RuntimeSystem` enum entry, which takes a vector of `PandocRuntimeSystemOption` enum values
- The `PandocRuntimeSystemOption::MaximumHeapMemory` entry, which takes a string representing the maximum heap memory size to use.

This way, the PandocRuntimeSystemOption enum can be extended as new parameters are supported.

Example code to use this feature :
```rust
    let mut pandoc = pandoc::new();
    pandoc.add_option(pandoc::PandocOption::RuntimeSystem(vec![
        // Limit the heap size to 512 MB while processing the arbitrary input file.
        pandoc::PandocRuntimeSystemOption::MaximumHeapMemory("512M".to_string()),
    ]));
    pandoc.add_input(&filepath);
    pandoc.set_output_format(pandoc::OutputFormat::Html5, vec![]);
    pandoc.set_output(pandoc::OutputKind::Pipe);
```