### PR TITLE
--no-wrap is deprecated, should use --wrap=none

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ impl PandocOption {
             PrintDefaultDataFile(ref f) => {
                 pandoc.args(&[&format!("--print-default-data-file={}", f.display())])
             }
-            NoWrap => pandoc.args(&["--no-wrap"]),
+            NoWrap => pandoc.args(&["--wrap=none"]),
             Columns(n) => pandoc.args(&[&format!("--columns={}", n)]),
             TableOfContents => pandoc.args(&["--table-of-contents"]),
             TableOfContentsDepth(d) => pandoc.args(&[&format!("--toc-depth={}", d)]),


### PR DESCRIPTION
--no-wrap is no longer accepted by pandoc, should be --wrap=none