### PR TITLE
Add rtf input format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,3 @@ description = "a library API that wraps calls to the pandoc 2.x executable"
 [dependencies]
 itertools = "0.8"
 
-[features]
-input-format-rtf = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ description = "a library API that wraps calls to the pandoc 2.x executable"
 
 [dependencies]
 itertools = "0.8"
+
+[features]
+rtf = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ description = "a library API that wraps calls to the pandoc 2.x executable"
 itertools = "0.8"
 
 [features]
-rtf = []
+input-format-rtf = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,6 +613,7 @@ pub enum InputFormat {
     /// reStructuredText
     Rst,
     /// Rich text format
+    #[cfg(feature = "rtf")]
     Rtf,
     /// HTML
     Html,
@@ -650,6 +651,7 @@ impl std::fmt::Display for InputFormat {
             MarkdownGithub => write!(fmt, "markdown_github"),
             Commonmark => write!(fmt, "commonmark"),
             Rst => write!(fmt, "rst"),
+            #[cfg(feature = "rtf")]
             Rtf => write!(fmt, "rtf"),
             Html => write!(fmt, "html"),
             Latex => write!(fmt, "latex"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,8 +612,8 @@ pub enum InputFormat {
     Textile,
     /// reStructuredText
     Rst,
-    /// Rich text format
-    #[cfg(feature = "input-format-rtf")]
+    /// Rich text format \
+    /// *Only available as of `pandoc 2.14.2 (2021-08-21)`*
     Rtf,
     /// HTML
     Html,
@@ -651,7 +651,6 @@ impl std::fmt::Display for InputFormat {
             MarkdownGithub => write!(fmt, "markdown_github"),
             Commonmark => write!(fmt, "commonmark"),
             Rst => write!(fmt, "rst"),
-            #[cfg(feature = "input-format-rtf")]
             Rtf => write!(fmt, "rtf"),
             Html => write!(fmt, "html"),
             Latex => write!(fmt, "latex"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,6 +612,8 @@ pub enum InputFormat {
     Textile,
     /// reStructuredText
     Rst,
+    /// Rich text format
+    Rtf,
     /// HTML
     Html,
     /// DocBook
@@ -648,6 +650,7 @@ impl std::fmt::Display for InputFormat {
             MarkdownGithub => write!(fmt, "markdown_github"),
             Commonmark => write!(fmt, "commonmark"),
             Rst => write!(fmt, "rst"),
+            Rtf => write!(fmt, "rtf"),
             Html => write!(fmt, "html"),
             Latex => write!(fmt, "latex"),
             MediaWiki => write!(fmt, "mediawiki"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,7 +613,7 @@ pub enum InputFormat {
     /// reStructuredText
     Rst,
     /// Rich text format
-    #[cfg(feature = "rtf")]
+    #[cfg(feature = "input-format-rtf")]
     Rtf,
     /// HTML
     Html,
@@ -651,7 +651,7 @@ impl std::fmt::Display for InputFormat {
             MarkdownGithub => write!(fmt, "markdown_github"),
             Commonmark => write!(fmt, "commonmark"),
             Rst => write!(fmt, "rst"),
-            #[cfg(feature = "rtf")]
+            #[cfg(feature = "input-format-rtf")]
             Rtf => write!(fmt, "rtf"),
             Html => write!(fmt, "html"),
             Latex => write!(fmt, "latex"),


### PR DESCRIPTION
Recently, pandoc added support for RTF as an input format. This PR adds support for it, gated behind the `input-format-rtf` feature.