### PR TITLE
change the docx format to a binary one

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1234,7 +1234,7 @@ impl Pandoc {
         match output_kind {
             Some(OutputKind::File(name)) => Ok(PandocOutput::ToFile(name)),
             Some(OutputKind::Pipe) => match output_format {
-                Some((OutputFormat::Pdf, ..)) => Ok(PandocOutput::ToBufferRaw(output)),
+                Some((OutputFormat::Pdf | OutputFormat::Docx, ..)) => Ok(PandocOutput::ToBufferRaw(output)),
 
                 _ => match String::from_utf8(output) {
                     Ok(string) => Ok(PandocOutput::ToBuffer(string)),


### PR DESCRIPTION
The docx format is a compressed xml format. When using pandoc it tried to parse the output stream in string. The output is not valid utf-8 so it fails